### PR TITLE
Fix for variables that were not reset in `reset()`

### DIFF
--- a/.settings/.gitignore
+++ b/.settings/.gitignore
@@ -1,0 +1,1 @@
+/org.eclipse.jdt.core.prefs

--- a/src/ai/coac/BuildModified.java
+++ b/src/ai/coac/BuildModified.java
@@ -73,7 +73,8 @@ public class BuildModified extends AbstractAction {
                 y == unit.getY()) ua = new UnitAction(UnitAction.TYPE_PRODUCE, UnitAction.DIRECTION_LEFT, type);
         if (ua != null && gs.isUnitActionAllowed(unit, ua)) return ua;
 
-        System.err.println("Build.execute: something weird just happened " + unit + " builds at " + x + "," + y);
+        // Failure usually seems to be that we simply don't have enough resources anymore
+        //System.err.println("Build.execute: something weird just happened " + unit + " builds at " + x + "," + y);
         return new UnitAction(UnitAction.TYPE_NONE, 1);
     }
 }

--- a/src/ai/coac/CoacAI.java
+++ b/src/ai/coac/CoacAI.java
@@ -1,17 +1,30 @@
 package ai.coac;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import ai.abstraction.AbstractionLayerAIWait1;
 import ai.abstraction.pathfinding.AStarPathFinding;
 import ai.core.AI;
 import ai.core.ParameterSpecification;
-import rts.*;
+import rts.GameState;
+import rts.PhysicalGameState;
+import rts.Player;
+import rts.PlayerAction;
+import rts.UnitAction;
+import rts.UnitActionAssignment;
 import rts.units.Unit;
 import rts.units.UnitType;
 import rts.units.UnitTypeTable;
-
-import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * @author https://github.com/Coac
@@ -78,6 +91,9 @@ public class CoacAI extends AbstractionLayerAIWait1 {
 
     public void reset() {
         super.reset();
+        harvesting.clear();
+        attackAll = false;
+        wasSeparated = false;
     }
 
 
@@ -311,15 +327,10 @@ public class CoacAI extends AbstractionLayerAIWait1 {
 
         if (p.getResources() == 0 && resources.size() == 0) {
             attackAll = true;
-            attackWithCombat = true;
         }
         int enemyCombatScore = enemyCombatUnits.stream().mapToInt(Unit::getCost).sum();
         int myCombatScore = myCombatUnits.stream().mapToInt(Unit::getCost).sum() + myCombatUnitsBusy.stream().mapToInt(Unit::getCost).sum();
-        if (myCombatScore - 4 > enemyCombatScore) {
-            attackWithCombat = true;
-        } else {
-            attackWithCombat = false;
-        }
+        attackWithCombat = (myCombatScore - 4 > enemyCombatScore);
 
         this.computeWorkersAction();
         if (this.map.equals("maps/16x16/basesWorkers16x16A.xml")) {

--- a/src/ai/coac/TrainDirection.java
+++ b/src/ai/coac/TrainDirection.java
@@ -4,6 +4,8 @@
  */
 package ai.coac;
 
+import java.util.Objects;
+
 import ai.abstraction.AbstractAction;
 import rts.GameState;
 import rts.ResourceUsage;
@@ -11,8 +13,6 @@ import rts.UnitAction;
 import rts.units.Unit;
 import rts.units.UnitType;
 import util.XMLWriter;
-
-import java.util.Objects;
 
 /**
  * @author santi
@@ -55,7 +55,8 @@ public class TrainDirection extends AbstractAction {
         UnitAction ua = new UnitAction(UnitAction.TYPE_PRODUCE, direction, type);
         if (gs.isUnitActionAllowed(unit, ua)) return ua;
 
-        System.out.println("WARNING: TrainDirection invalid direction");
+        // Failure usually seems to be that we simply don't have enough resources anymore
+        //System.out.println("WARNING: TrainDirection invalid direction");
         return new UnitAction(UnitAction.TYPE_NONE, 1);
     }
 }


### PR DESCRIPTION
I found a few variables that looked like they were not correctly reset by the `reset()` method. Well, actually, nothing was reset there, but most variables would implicitly get reset correctly by the `init()` call at the start of every `getAction()` call. Not the case for a few exceptions, which I'm now resetting here.

I suspect that these may explain the issue reported by Costa in Issue #1: in particular, the `attackAll` flag not resetting looks like it might cause the behaviour that Costa observed.

(ignore all the import changes, those were all just done automatically by my Eclipse IDE)